### PR TITLE
Configure sections using a custom string format

### DIFF
--- a/doc/firewall.md
+++ b/doc/firewall.md
@@ -4,28 +4,66 @@ Security firewall configuration
 Once your sections are registered and configured, you can use the parameters 
 for various parts of your application. Including the security firewalls.
 
-Say you have two sections with the same service-prefix `acme.section`,
+Say you have two sections with the same service-prefix `app.section`,
 and want to configure the firewalls:
 
 ```yaml
-# config/packages/security.yml
+# config/packages/security.yaml
 security:
 
     # ...
 
     firewalls:
         frontend:
-            pattern: '%acme.section.frontend.path%'
-            host: '%acme.section.frontend.path%'
+            pattern: '%app.section.frontend.path%'
+            host: '%app.section.frontend.path%'
 
             # Or if you have no special matcher requirements
-            # request_matcher: acme.section.frontend.request_matcher
+            # request_matcher: app.section.frontend.request_matcher
+            
+            # remember_me:
+            #     secret:               '%kernel.secret%'
+            #     token_provider:       ~
+            #     catch_exceptions:     true
+            #     name:                 FRONTEND_REMEMBERME
+            #     lifetime:             604800 # one week
+            #     path:                 '%app.section.frontend.prefix%'
+            #     domain:               '%app.section.frontend.domain%'
+            #     secure:               '%app.section.frontend.is_secure%'
+            #     httponly:             true
+            #     always_remember_me:   false
 
         backend:
-            request_matcher: acme.section.backend.request_matcher
+            request_matcher: app.section.backend.request_matcher
+
+    access_control:
+        # Notice. Path always ends with a /
+        
+        # Backend
+        -
+            path: '%app.section.backend.path%login$', 
+            host: '%app.section.backend.host_pattern%'
+            requires_channel: '%app.section.backend.channel%'
+            
+            role: IS_AUTHENTICATED_ANONYMOUSLY
+        
+        -
+            path: '%app.section.backend.path%'
+            host: '%app.section.backend.host_pattern%'
+            requires_channel: '%app.section.backend.channel%'
+            
+            role: ROLE_ADMIN
+
+        # Frontend
+        -
+            path: '%app.section.frontend.path%'
+            host: '%app.section.frontend.host_pattern%'
+            requires_channel: '%app.section.frontend.channel%'
+            
+            role: ROLE_USER
 
 ```
 
 That's it, the firewall will now use the sections configuration.
 And don't worry about the correct order, each path is constructed
-to never match for other sections!
+to never match for other sections within the same host group!

--- a/doc/routing.md
+++ b/doc/routing.md
@@ -4,8 +4,7 @@ Routing configuration
 If you already configured the [security firewalls](firewall.md) it's now time 
 to configure the routing.
 
-**Note:** A section needs to be at the root of importing, you cannot import 
-a section as part of another import with a prefix and/or host.
+**Note:** A section needs to be at the root of importing (eg. config/routes.yaml).
 
 ## Route loader
 
@@ -19,11 +18,11 @@ resource type.
 ```yaml
 # config/routes.yml
 
-_acme_frontend:
-    resource: 'frontend:yml#@AcmeCoreBundle/Resources/config/routing/frontend.yml'
+_app_frontend:
+    resource: 'frontend:yml#@AppCoreBundle/Resources/config/routing/frontend.yml'
     type: app_section
 
-_acme_backend:
-    resource: 'backend#@AcmeCoreBundle/Resources/config/routing/backend.yml'
+_app_backend:
+    resource: 'backend#@AppCoreBundle/Resources/config/routing/backend.yml'
     type: app_section
 ```

--- a/src/Routing/AppSectionRouteLoader.php
+++ b/src/Routing/AppSectionRouteLoader.php
@@ -84,12 +84,15 @@ final class AppSectionRouteLoader extends Loader
         // N.B. this needs to be called 'after' the importing!
         $collection->addPrefix($section['prefix']);
 
-        if (isset($this->sections[$parts['section']]['host'])) {
+        if (isset($section['host'])) {
             $collection->setHost($section['host']);
+            $collection->addRequirements($section['requirements']);
+            $collection->addDefaults($section['defaults']);
         }
 
-        $collection->addRequirements($section['requirements'] ?? []);
-        $collection->addDefaults($section['defaults'] ?? []);
+        if ($section['is_secure']) {
+            $collection->setSchemes(['https']);
+        }
 
         return $collection;
     }

--- a/src/SectioningFactory.php
+++ b/src/SectioningFactory.php
@@ -60,11 +60,11 @@ final class SectioningFactory
      * Set the configuration for a section.
      *
      * @param string $name   Name of the section, must be unique within the service-prefix
-     * @param array  $config Configuration of the section, must contain a 'prefix' key
+     * @param string $config Configuration of the section, URI pattern
      *
      * @return SectioningFactory Fluent interface
      */
-    public function set(string $name, array $config): self
+    public function set(string $name, string $config): self
     {
         try {
             $this->sections[$name] = new SectionConfiguration($config);
@@ -88,46 +88,5 @@ final class SectioningFactory
         $this->container->register('rollerworks.app_section.route_loader', AppSectionRouteLoader::class)
             ->setArguments([new Reference('routing.resolver'), $configurator->exportConfiguration()])
             ->addTag('routing.loader');
-    }
-
-    /**
-     * @throws \InvalidArgumentException When the configuration is invalid
-     */
-    public function fromArray(array $required, array $sections): self
-    {
-        $missingKeys = [];
-
-        foreach ($required as $key) {
-            if (!array_key_exists($key, $sections)) {
-                $missingKeys[] = $key;
-            } elseif (!\is_array($sections[$key])) {
-                throw new \InvalidArgumentException(sprintf('AppSection "%s" configuration expects an array got %s instead.', $key, gettype($sections[$key])));
-            } else {
-                $this->set($key, $sections[$key]);
-            }
-        }
-
-        if ($missingKeys) {
-            throw new \InvalidArgumentException(sprintf('The following AppSections are required but were not set: %s', implode(', ', $missingKeys)));
-        }
-
-        return $this;
-    }
-
-    public function fromJson(array $required, string $value): self
-    {
-        $sections = json_decode($value, true, 512, JSON_BIGINT_AS_STRING);
-
-        if (null === $sections) {
-            throw new \InvalidArgumentException(sprintf('AppSections configuration is invalid. Message: %s', json_last_error_msg()));
-        }
-
-        if (!\is_array($sections)) {
-            throw new \InvalidArgumentException('AppSections configuration is expected to be an array.');
-        }
-
-        $this->fromArray($required, $sections);
-
-        return $this;
     }
 }

--- a/src/SectionsConfigurator.php
+++ b/src/SectionsConfigurator.php
@@ -23,51 +23,62 @@ use Symfony\Component\HttpFoundation\RequestMatcher;
  *
  * Say there are two sections:
  *
- * * Frontend - host: example.com prefix: /
- * * Backend  - host: example.com prefix: backend/
+ * * Frontend - example.com/
+ * * Backend  - example.com/backend/
  *
  * Unless the 'backend' section is tried earlier the 'frontend' will always match!
  * To prevent this the path (regex) is configured to never match 'backend/'.
- * Only when both share the same host and only there is an actual conflict.
+ * Only when both match the same host and only when there is a prefix conflict.
  *
  * Note: For routing the prefix doesn't use a negative look-ahead,
- * as router performs full matches.
+ * as the router performs full matches.
  *
  * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ *
+ * @internal
  */
 final class SectionsConfigurator
 {
+    /**
+     * @var SectionConfiguration[]
+     */
     private $sections = [];
+    private $exportedSections = [];
     private $processed;
 
     public function set(string $name, SectionConfiguration $config)
     {
-        $this->sections[$name] = $config->getConfig();
-        $this->sections[$name]['config'] = $config;
-        $this->processed = null;
+        $this->sections[$name] = $config;
+
+        if (null !== $this->processed) {
+            throw new \RuntimeException('Cannot register new sections after processing.');
+        }
     }
 
-    /**
-     * Process the registered sections configuration.
-     *
-     * @throws ValidatorException When one ore more sections have a conflicting configuration
-     */
     public function process(): void
     {
+        if (null !== $this->processed) {
+            return;
+        }
+
         $conflicts = [];
         $this->processed = $this->groupSectionsPerHost();
 
-        foreach ($this->processed as $hostIndex => $configs) {
+        foreach ($this->processed as $hostIndex => $sectionsInHost) {
             $prefixes = [];
 
-            foreach ($configs as $section => $config) {
-                $prefix = $config['prefix'];
+            /** @var SectionConfiguration $config */
+            foreach ($sectionsInHost as $section => $config) {
+                $prefix = $config->prefix;
 
                 if (isset($prefixes[$prefix])) {
                     $conflicts[$prefixes[$prefix]][] = $section;
                 } else {
                     $prefixes[$prefix] = $section;
                 }
+
+                $this->sections[$section]->path = $this->generateSectionPath($section, $sectionsInHost);
+                $this->exportedSections[$section] = $this->sections[$section]->toArray();
             }
         }
 
@@ -85,32 +96,41 @@ final class SectionsConfigurator
      *
      * Like:
      *
+     * '{service-prefix}.{section-name}.is_secure'        => false
+     * '{service-prefix}.{section-name}.channel'          => null
      * '{service-prefix}.{section-name}.host'             => 'example.com'
      * '{service-prefix}.{section-name}.host_pattern'     => '^example\.com$'
      * '{service-prefix}.{section-name}.prefix'           => '/'
      * '{service-prefix}.{section-name}.path'             => '^/(?!(backend|api)/)'
      * '{service-prefix}.{section-name}.request_matcher'  => {RequestMatcher service}
      *
-     * Note: when the host is empty the 'host_pattern' is '.*' (as the route requirement)
-     * cannot be empty. The host pattern for the request_matcher is null then.
+     * Note: when the host is empty the 'host_pattern' is null.
+     *
+     * The `channel` is only set to 'https' when is_secure is true. This prevents forcing
+     * an HTTP channel when HTTPS is used. HTTPS is only enforced when configured.
      *
      * @param ContainerBuilder $container
+     * @param string           $servicePrefix
      */
-    public function registerToContainer(ContainerBuilder $container, string $servicePrefix)
+    public function registerToContainer(ContainerBuilder $container, string $servicePrefix): void
     {
+        $this->process();
         $servicePrefix = rtrim($servicePrefix, '.').'.';
 
-        foreach ($this->resolveSections() as $name => $config) {
-            $container->setParameter($servicePrefix.$name.'.host', (string) $config['host']);
-            $container->setParameter($servicePrefix.$name.'.host_pattern', (string) ($config['host_pattern'] ?: '.*'));
-            $container->setParameter($servicePrefix.$name.'.requirements', $config['requirements']);
-            $container->setParameter($servicePrefix.$name.'.defaults', $config['defaults']);
-            $container->setParameter($servicePrefix.$name.'.prefix', $config['prefix']);
-            $container->setParameter($servicePrefix.$name.'.path', $config['path']);
+        foreach ($this->sections as $name => $config) {
+            $container->setParameter($servicePrefix.$name.'.is_secure', $config->isSecure);
+            $container->setParameter($servicePrefix.$name.'.channel', $config->isSecure ? 'https' : null);
+            $container->setParameter($servicePrefix.$name.'.domain', $config->domain);
+            $container->setParameter($servicePrefix.$name.'.host', $config->host);
+            $container->setParameter($servicePrefix.$name.'.host_pattern', $config->hostPattern);
+            $container->setParameter($servicePrefix.$name.'.requirements', $config->requirements);
+            $container->setParameter($servicePrefix.$name.'.defaults', $config->defaults);
+            $container->setParameter($servicePrefix.$name.'.prefix', $config->prefix);
+            $container->setParameter($servicePrefix.$name.'.path', $config->path);
             $container->register($servicePrefix.$name.'.request_matcher', RequestMatcher::class)->setArguments(
                 [
-                    $container->getParameterBag()->escapeValue($config['path']),
-                    $container->getParameterBag()->escapeValue($config['host_pattern']),
+                    $container->getParameterBag()->escapeValue($config->path),
+                    $container->getParameterBag()->escapeValue($config->hostPattern),
                 ]
             );
         }
@@ -120,34 +140,18 @@ final class SectionsConfigurator
      * Returns resolved sections.
      *
      * The returned structure is as follow (value is an associative array):
-     * [section-name] => [host, host_pattern, prefix, path]
+     * [section-name] => [is_secure, host, host_pattern, prefix, path]
      *
      * @return array[]
      */
     public function exportConfiguration(): array
     {
-        return $this->resolveSections();
+        $this->process();
+
+        return $this->exportedSections;
     }
 
-    private function resolveSections(): array
-    {
-        if (null === $this->processed) {
-            $this->process();
-        }
-
-        $sections = [];
-
-        foreach ($this->processed as $sectionsInHost) {
-            foreach ($sectionsInHost as $name => $hostSections) {
-                $sections[$name] = $this->generateSectionPath($name, $sectionsInHost);
-                unset($sections[$name]['config']);
-            }
-        }
-
-        return $sections;
-    }
-
-    private function groupSectionsPerHost()
+    private function groupSectionsPerHost(): array
     {
         $hostsSections = [];
         $sections2 = $this->sections;
@@ -163,7 +167,7 @@ final class SectionsConfigurator
             $hostsSections[$hostIndex][$name] = $config;
 
             foreach ($sections2 as $name2 => $config2) {
-                if ($config['config']->hostEquals($config2['config'])) {
+                if ($config->hostEquals($config2)) {
                     $hostsSections[$processed[$name]][$name2] = $config2;
                     $processed[$name2] = $processed[$name];
                 }
@@ -181,8 +185,8 @@ final class SectionsConfigurator
 
         foreach ($conflicts as $primary => $sections) {
             $failedSections[$primary] = [
-                $this->sections[$primary]['host_pattern'],
-                $this->sections[$primary]['prefix'],
+                $this->sections[$primary]->hostPattern,
+                $this->sections[$primary]->prefix,
                 $sections,
             ];
         }
@@ -190,27 +194,24 @@ final class SectionsConfigurator
         return $failedSections;
     }
 
-    private function generateSectionPath(string $name, array $allSections): array
+    private function generateSectionPath(string $name, array $allSections): string
     {
         $config = $allSections[$name];
         unset($allSections[$name]);
 
         $negativePrefixes = [];
-
         foreach (array_column($allSections, 'prefix') as $prefix) {
-            $negativePrefixes[] = $this->findNoneMatchingPath($config['prefix'], $prefix);
+            $negativePrefixes[] = $this->findNoneMatchingPath($config->prefix, $prefix);
         }
 
         $negativePath = implode('|', array_map('preg_quote', array_filter(array_unique($negativePrefixes))));
-        $path = '^/'.preg_quote(ltrim($config['prefix'], '/'), '#');
+        $path = '^/'.preg_quote(ltrim($config->prefix, '/'), '#');
 
         if ($negativePath) {
             $path .= "(?!($negativePath)/)";
         }
 
-        $config['path'] = $path;
-
-        return $config;
+        return $path;
     }
 
     private function findNoneMatchingPath(string $currentPrefix, string $otherPrefix): string

--- a/tests/Functional/Application/AppKernel.php
+++ b/tests/Functional/Application/AppKernel.php
@@ -85,8 +85,10 @@ class AppKernel extends Kernel
     {
         $loader->load($this->config);
 
+        $sections = $container->getParameter('app_sections');
         (new SectioningFactory($container, 'park_manager.section'))
-            ->fromArray(['backend', 'frontend'], $container->getParameter('app_sections'))
+            ->set('backend', $sections['backend'])
+            ->set('frontend', $sections['frontend'])
             ->register();
     }
 

--- a/tests/Functional/Application/config/default.yml
+++ b/tests/Functional/Application/config/default.yml
@@ -3,11 +3,5 @@ imports:
 
 parameters:
     app_sections:
-        backend:
-            prefix: backend/
-            host: example.{tld}
-            requirements: { id: '\d+', tld: com }
-            defaults: { tld: com }
-        frontend:
-            prefix: /
-            host: null
+        backend: 'example.{tld;com;com}/backend'
+        frontend: '/'

--- a/tests/Routing/AppSectionRouteLoaderTest.php
+++ b/tests/Routing/AppSectionRouteLoaderTest.php
@@ -29,16 +29,19 @@ final class AppSectionRouteLoaderTest extends TestCase
 
     private const APP_SECTIONS = [
         'api' => [
+            'is_secure' => true,
             'prefix' => 'api/',
             'requirements' => [],
             'defaults' => [],
         ],
         'frontend' => [
+            'is_secure' => false,
             'prefix' => '/',
             'requirements' => [],
             'defaults' => [],
         ],
         'backend' => [
+            'is_secure' => true,
             'prefix' => '/',
             'host' => 'example.{tld}',
             'requirements' => ['tld' => 'net|com'],
@@ -127,10 +130,12 @@ final class AppSectionRouteLoaderTest extends TestCase
         $routeCollection2 = new RouteCollection();
         $routeCollection2->add('backend_main', new Route('/', ['tld' => 'com'], ['tld' => 'net|com'], [], 'example.{tld}'));
         $routeCollection2->add('backend_user', new Route('user/', ['tld' => 'com'], ['tld' => 'net|com'], [], 'example.{tld}'));
+        $routeCollection2->setSchemes(['https']);
 
         $routeCollection3 = new RouteCollection();
         $routeCollection3->add('frontend_news', new Route('api/news/'));
         $routeCollection3->add('frontend_blog', new Route('api/blog/'));
+        $routeCollection3->setSchemes(['https']);
 
         $this->assertEquals($routeCollection1, $this->loader->load('frontend#something.yml'));
         $this->assertEquals($routeCollection2, $this->loader->load('backend:xml#something.xml'));

--- a/tests/SectioningFactoryTest.php
+++ b/tests/SectioningFactoryTest.php
@@ -25,8 +25,8 @@ final class SectioningFactoryTest extends AbstractContainerBuilderTestCase
     public function it_registers_sections_in_the_container()
     {
         $factory = new SectioningFactory($this->container, 'acme.section');
-        $factory->set('frontend', ['prefix' => '/', 'host' => 'example.com']);
-        $factory->set('backend', ['prefix' => 'backend', 'host' => 'example.com']);
+        $factory->set('frontend', 'example.com/');
+        $factory->set('backend', 'https://example.com/backend');
         $factory->register();
 
         $this->assertContainerBuilderHasService('rollerworks.app_section.route_loader', AppSectionRouteLoader::class);
@@ -35,19 +35,23 @@ final class SectioningFactoryTest extends AbstractContainerBuilderTestCase
             1,
             [
                 'frontend' => [
+                    'is_secure' => false,
+                    'domain' => 'example.com',
                     'host' => 'example.com',
+                    'host_pattern' => '^example\.com$',
+                    'prefix' => '/',
                     'defaults' => [],
                     'requirements' => [],
-                    'prefix' => '/',
-                    'host_pattern' => '^example\.com$',
                     'path' => '^/(?!(backend)/)',
                 ],
                 'backend' => [
+                    'is_secure' => true,
+                    'domain' => 'example.com',
                     'host' => 'example.com',
+                    'host_pattern' => '^example\.com$',
+                    'prefix' => 'backend/',
                     'defaults' => [],
                     'requirements' => [],
-                    'prefix' => 'backend/',
-                    'host_pattern' => '^example\.com$',
                     'path' => '^/backend/',
                 ],
             ]
@@ -60,143 +64,13 @@ final class SectioningFactoryTest extends AbstractContainerBuilderTestCase
     /**
      * @test
      */
-    public function it_registers_sections_from_array()
-    {
-        $factory = new SectioningFactory($this->container, 'acme.section');
-        $factory->fromArray(['frontend', 'backend'], [
-            'frontend' => ['prefix' => '/', 'host' => 'example.com'],
-            'backend' => ['prefix' => 'backend', 'host' => 'example.com'],
-        ]);
-        $factory->register();
-
-        $this->assertContainerBuilderHasService('rollerworks.app_section.route_loader', AppSectionRouteLoader::class);
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'rollerworks.app_section.route_loader',
-            1,
-            [
-                'frontend' => [
-                    'host' => 'example.com',
-                    'defaults' => [],
-                    'requirements' => [],
-                    'prefix' => '/',
-                    'host_pattern' => '^example\.com$',
-                    'path' => '^/(?!(backend)/)',
-                ],
-                'backend' => [
-                    'host' => 'example.com',
-                    'defaults' => [],
-                    'requirements' => [],
-                    'prefix' => 'backend/',
-                    'host_pattern' => '^example\.com$',
-                    'path' => '^/backend/',
-                ],
-            ]
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function it_registers_sections_from_json()
-    {
-        $factory = new SectioningFactory($this->container, 'acme.section');
-        $factory->fromJson(['frontend', 'backend'], json_encode([
-            'frontend' => ['prefix' => '/', 'host' => 'example.com'],
-            'backend' => ['prefix' => 'backend', 'host' => 'example.com'],
-        ]));
-        $factory->register();
-
-        $this->assertContainerBuilderHasService('rollerworks.app_section.route_loader', AppSectionRouteLoader::class);
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'rollerworks.app_section.route_loader',
-            1,
-            [
-                'frontend' => [
-                    'host' => 'example.com',
-                    'defaults' => [],
-                    'requirements' => [],
-                    'prefix' => '/',
-                    'host_pattern' => '^example\.com$',
-                    'path' => '^/(?!(backend)/)',
-                ],
-                'backend' => [
-                    'host' => 'example.com',
-                    'defaults' => [],
-                    'requirements' => [],
-                    'prefix' => 'backend/',
-                    'host_pattern' => '^example\.com$',
-                    'path' => '^/backend/',
-                ],
-            ]
-        );
-    }
-
-    /**
-     * @test
-     */
-    public function it_validates_register_by_array_for_required_sections()
+    public function it_informs_errors()
     {
         $factory = new SectioningFactory($this->container, 'acme.section');
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('The following AppSections are required but were not set: backend, api');
+        $this->expectExceptionMessage('AppSection "frontend" configuration is invalid: ');
 
-        $factory->fromArray(['frontend', 'backend', 'api'], [
-            'frontend' => ['prefix' => '/', 'host' => 'example.com'],
-        ]);
-    }
-
-    /**
-     * @test
-     */
-    public function it_validates_register_by_array_for_correct_structure()
-    {
-        $factory = new SectioningFactory($this->container, 'acme.section');
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('AppSection "frontend" configuration expects an array got NULL instead.');
-
-        $factory->fromArray(['frontend'], [
-            'frontend' => null,
-        ]);
-    }
-
-    /**
-     * @test
-     */
-    public function it_validates_register_by_array_for_correct_syntax()
-    {
-        $factory = new SectioningFactory($this->container, 'acme.section');
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('AppSections configuration is invalid. Message: Syntax error');
-
-        $factory->fromJson(['frontend', 'backend', 'api'], '[');
-    }
-
-    /**
-     * @test
-     */
-    public function it_validates_register_by_array_for_correct_input()
-    {
-        $factory = new SectioningFactory($this->container, 'acme.section');
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('AppSections configuration is expected to be an array.');
-
-        $factory->fromJson(['frontend', 'backend', 'api'], '"Nope"');
-    }
-
-    /**
-     * @test
-     */
-    public function it_informs_errors_()
-    {
-        $factory = new SectioningFactory($this->container, 'acme.section');
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('AppSection "frontend" configuration is invalid: Missing requirement for attribute "com".');
-
-        $factory->set('frontend', ['prefix' => '/', 'host' => 'example.{com}']);
+        $factory->set('frontend', 'https://');
     }
 }

--- a/tests/SectionsConfiguratorTest.php
+++ b/tests/SectionsConfiguratorTest.php
@@ -28,22 +28,26 @@ final class SectionsConfiguratorTest extends TestCase
     public function it_configures_the_paths_by_prefix()
     {
         $configurator = new SectionsConfigurator();
-        $configurator->set('frontend', new SectionConfiguration(['prefix' => 'client/', 'requirements' => ['foo' => '\d+']]));
-        $configurator->set('backend', new SectionConfiguration(['prefix' => 'backend']));
+        $configurator->set('frontend', new SectionConfiguration('/client/'));
+        $configurator->set('backend', new SectionConfiguration('https://example.com/backend'));
 
         $this->assertEquals(
             [
                 'frontend' => [
+                    'is_secure' => false,
                     'host' => null,
+                    'domain' => null,
                     'host_pattern' => null,
                     'prefix' => 'client/',
                     'path' => '^/client/',
-                    'requirements' => ['foo' => '\d+'],
+                    'requirements' => [],
                     'defaults' => [],
                 ],
                 'backend' => [
-                    'host' => null,
-                    'host_pattern' => null,
+                    'is_secure' => true,
+                    'host' => 'example.com',
+                    'domain' => 'example.com',
+                    'host_pattern' => '^example\.com$',
                     'prefix' => 'backend/',
                     'path' => '^/backend/',
                     'requirements' => [],
@@ -60,13 +64,15 @@ final class SectionsConfiguratorTest extends TestCase
     public function it_configures_the_host_pattern_by_host()
     {
         $configurator = new SectionsConfigurator();
-        $configurator->set('frontend', new SectionConfiguration(['prefix' => '/', 'host' => 'example.net']));
-        $configurator->set('backend', new SectionConfiguration(['prefix' => '/', 'host' => 'example.com']));
+        $configurator->set('frontend', new SectionConfiguration('example.net/'));
+        $configurator->set('backend', new SectionConfiguration('example.com/'));
 
         $this->assertEquals(
             [
                 'frontend' => [
+                    'is_secure' => false,
                     'host' => 'example.net',
+                    'domain' => 'example.net',
                     'host_pattern' => '^example\.net$',
                     'prefix' => '/',
                     'path' => '^/',
@@ -74,7 +80,9 @@ final class SectionsConfiguratorTest extends TestCase
                     'defaults' => [],
                 ],
                 'backend' => [
+                    'is_secure' => false,
                     'host' => 'example.com',
+                    'domain' => 'example.com',
                     'host_pattern' => '^example\.com$',
                     'prefix' => '/',
                     'path' => '^/',
@@ -92,14 +100,16 @@ final class SectionsConfiguratorTest extends TestCase
     public function its_configured_path_excludes_other_paths()
     {
         $configurator = new SectionsConfigurator();
-        $configurator->set('frontend', new SectionConfiguration(['prefix' => '/']));
-        $configurator->set('backend', new SectionConfiguration(['prefix' => 'backend']));
-        $configurator->set('api', new SectionConfiguration(['prefix' => 'api']));
+        $configurator->set('frontend', new SectionConfiguration('/'));
+        $configurator->set('backend', new SectionConfiguration('/backend'));
+        $configurator->set('api', new SectionConfiguration('/api'));
 
         $this->assertEquals(
             [
                 'frontend' => [
+                    'is_secure' => false,
                     'host' => null,
+                    'domain' => null,
                     'host_pattern' => null,
                     'prefix' => '/',
                     'path' => '^/(?!(backend|api)/)',
@@ -107,7 +117,9 @@ final class SectionsConfiguratorTest extends TestCase
                     'defaults' => [],
                 ],
                 'backend' => [
+                    'is_secure' => false,
                     'host' => null,
+                    'domain' => null,
                     'host_pattern' => null,
                     'prefix' => 'backend/',
                     'path' => '^/backend/',
@@ -115,7 +127,9 @@ final class SectionsConfiguratorTest extends TestCase
                     'defaults' => [],
                 ],
                 'api' => [
+                    'is_secure' => false,
                     'host' => null,
+                    'domain' => null,
                     'host_pattern' => null,
                     'prefix' => 'api/',
                     'path' => '^/api/',
@@ -133,15 +147,17 @@ final class SectionsConfiguratorTest extends TestCase
     public function its_configured_path_excludes_other_sub_paths()
     {
         $configurator = new SectionsConfigurator();
-        $configurator->set('frontend', new SectionConfiguration(['prefix' => '/']));
-        $configurator->set('backend', new SectionConfiguration(['prefix' => 'backend']));
-        $configurator->set('backend_api', new SectionConfiguration(['prefix' => 'api/backend']));
-        $configurator->set('api', new SectionConfiguration(['prefix' => 'api']));
+        $configurator->set('frontend', new SectionConfiguration('/'));
+        $configurator->set('backend', new SectionConfiguration('/backend'));
+        $configurator->set('backend_api', new SectionConfiguration('/api/backend'));
+        $configurator->set('api', new SectionConfiguration('/api'));
 
         $this->assertEquals(
             [
                 'frontend' => [
+                    'is_secure' => false,
                     'host' => null,
+                    'domain' => null,
                     'host_pattern' => null,
                     'prefix' => '/',
                     'path' => '^/(?!(backend|api)/)',
@@ -149,7 +165,9 @@ final class SectionsConfiguratorTest extends TestCase
                     'defaults' => [],
                 ],
                 'backend' => [
+                    'is_secure' => false,
                     'host' => null,
+                    'domain' => null,
                     'host_pattern' => null,
                     'prefix' => 'backend/',
                     'path' => '^/backend/',
@@ -157,7 +175,9 @@ final class SectionsConfiguratorTest extends TestCase
                     'defaults' => [],
                 ],
                 'backend_api' => [
+                    'is_secure' => false,
                     'host' => null,
+                    'domain' => null,
                     'host_pattern' => null,
                     'prefix' => 'api/backend/',
                     'path' => '^/api/backend/',
@@ -165,7 +185,9 @@ final class SectionsConfiguratorTest extends TestCase
                     'defaults' => [],
                 ],
                 'api' => [
+                    'is_secure' => false,
                     'host' => null,
+                    'domain' => null,
                     'host_pattern' => null,
                     'prefix' => 'api/',
                     'path' => '^/api/(?!(backend)/)',
@@ -183,14 +205,16 @@ final class SectionsConfiguratorTest extends TestCase
     public function its_configured_path_excludes_other_sub_paths_in_host()
     {
         $configurator = new SectionsConfigurator();
-        $configurator->set('frontend', new SectionConfiguration(['prefix' => '/', 'host' => 'example.com']));
-        $configurator->set('backend', new SectionConfiguration(['prefix' => 'backend', 'host' => 'example.com']));
-        $configurator->set('backend_api', new SectionConfiguration(['prefix' => 'api/backend', 'host' => 'example.com']));
-        $configurator->set('api', new SectionConfiguration(['prefix' => 'api', 'host' => 'example.com']));
+        $configurator->set('frontend', new SectionConfiguration('example.com/'));
+        $configurator->set('backend', new SectionConfiguration('example.com/backend'));
+        $configurator->set('backend_api', new SectionConfiguration('example.com/api/backend'));
+        $configurator->set('api', new SectionConfiguration('example.com/api'));
 
         $this->assertEquals(
             [
                 'frontend' => [
+                    'is_secure' => false,
+                    'domain' => 'example.com',
                     'host' => 'example.com',
                     'host_pattern' => '^example\.com$',
                     'prefix' => '/',
@@ -199,6 +223,8 @@ final class SectionsConfiguratorTest extends TestCase
                     'defaults' => [],
                 ],
                 'backend' => [
+                    'is_secure' => false,
+                    'domain' => 'example.com',
                     'host' => 'example.com',
                     'host_pattern' => '^example\.com$',
                     'prefix' => 'backend/',
@@ -207,6 +233,8 @@ final class SectionsConfiguratorTest extends TestCase
                     'defaults' => [],
                 ],
                 'backend_api' => [
+                    'is_secure' => false,
+                    'domain' => 'example.com',
                     'host' => 'example.com',
                     'host_pattern' => '^example\.com$',
                     'prefix' => 'api/backend/',
@@ -215,6 +243,8 @@ final class SectionsConfiguratorTest extends TestCase
                     'defaults' => [],
                 ],
                 'api' => [
+                    'is_secure' => false,
+                    'domain' => 'example.com',
                     'host' => 'example.com',
                     'host_pattern' => '^example\.com$',
                     'prefix' => 'api/',
@@ -233,14 +263,16 @@ final class SectionsConfiguratorTest extends TestCase
     public function its_configured_path_excludes_other_sub_paths_in_host_pattern()
     {
         $configurator = new SectionsConfigurator();
-        $configurator->set('frontend', new SectionConfiguration(['prefix' => '/', 'host' => 'example.{tld}', 'requirements' => ['tld' => 'com|net'], 'defaults' => ['tld' => 'com']]));
-        $configurator->set('backend', new SectionConfiguration(['prefix' => 'backend', 'host' => 'example.com']));
-        $configurator->set('backend_api', new SectionConfiguration(['prefix' => 'api/backend', 'host' => 'example.com']));
-        $configurator->set('api', new SectionConfiguration(['prefix' => 'api', 'host' => 'example.com']));
+        $configurator->set('frontend', new SectionConfiguration('example.{tld;com;com|net}/'));
+        $configurator->set('backend', new SectionConfiguration('example.com/backend'));
+        $configurator->set('backend_api', new SectionConfiguration('example.com/api/backend'));
+        $configurator->set('api', new SectionConfiguration('example.com/api'));
 
         $this->assertEquals(
             [
                 'frontend' => [
+                    'is_secure' => false,
+                    'domain' => null,
                     'host' => 'example.{tld}',
                     'host_pattern' => '^example\.(?P<tld>com|net)$',
                     'prefix' => '/',
@@ -249,6 +281,8 @@ final class SectionsConfiguratorTest extends TestCase
                     'defaults' => ['tld' => 'com'],
                 ],
                 'backend' => [
+                    'is_secure' => false,
+                    'domain' => 'example.com',
                     'host' => 'example.com',
                     'host_pattern' => '^example\.com$',
                     'prefix' => 'backend/',
@@ -257,6 +291,8 @@ final class SectionsConfiguratorTest extends TestCase
                     'defaults' => [],
                 ],
                 'backend_api' => [
+                    'is_secure' => false,
+                    'domain' => 'example.com',
                     'host' => 'example.com',
                     'host_pattern' => '^example\.com$',
                     'prefix' => 'api/backend/',
@@ -265,6 +301,8 @@ final class SectionsConfiguratorTest extends TestCase
                     'defaults' => [],
                 ],
                 'api' => [
+                    'is_secure' => false,
+                    'domain' => 'example.com',
                     'host' => 'example.com',
                     'host_pattern' => '^example\.com$',
                     'prefix' => 'api/',
@@ -285,17 +323,15 @@ final class SectionsConfiguratorTest extends TestCase
         $container = new ContainerBuilder();
 
         $configurator = new SectionsConfigurator();
-        $configurator->set('frontend', new SectionConfiguration(['prefix' => '/', 'host' => 'example.com']));
-        $configurator->set('backend', new SectionConfiguration([
-                'prefix' => 'backend',
-                'host' => 'example.{tld}',
-                'defaults' => ['tld' => 'com'],
-                'requirements' => ['tld' => 'com|net'],
-            ])
+        $configurator->set('frontend', new SectionConfiguration('https://example.com/'));
+        $configurator->set('backend', new SectionConfiguration('example.{tld;com;com|net}/backend')
         );
 
         $configurator->registerToContainer($container, 'acme.section');
 
+        $this->assertTrue($container->hasParameter('acme.section.frontend.is_secure'));
+        $this->assertTrue($container->hasParameter('acme.section.frontend.channel'));
+        $this->assertTrue($container->hasParameter('acme.section.frontend.domain'));
         $this->assertTrue($container->hasParameter('acme.section.frontend.host'));
         $this->assertTrue($container->hasParameter('acme.section.frontend.host_pattern'));
         $this->assertTrue($container->hasParameter('acme.section.frontend.requirements'));
@@ -304,6 +340,9 @@ final class SectionsConfiguratorTest extends TestCase
         $this->assertTrue($container->hasParameter('acme.section.frontend.path'));
         $this->assertTrue($container->hasDefinition('acme.section.frontend.request_matcher'));
 
+        $this->assertTrue($container->hasParameter('acme.section.backend.is_secure'));
+        $this->assertTrue($container->hasParameter('acme.section.backend.channel'));
+        $this->assertTrue($container->hasParameter('acme.section.backend.domain'));
         $this->assertTrue($container->hasParameter('acme.section.backend.host'));
         $this->assertTrue($container->hasParameter('acme.section.backend.host_pattern'));
         $this->assertTrue($container->hasParameter('acme.section.backend.requirements'));
@@ -312,6 +351,9 @@ final class SectionsConfiguratorTest extends TestCase
         $this->assertTrue($container->hasParameter('acme.section.backend.path'));
         $this->assertTrue($container->hasDefinition('acme.section.backend.request_matcher'));
 
+        $this->assertTrue($container->getParameter('acme.section.frontend.is_secure'));
+        $this->assertEquals('https', $container->getParameter('acme.section.frontend.channel'));
+        $this->assertEquals('example.com', $container->getParameter('acme.section.frontend.domain'));
         $this->assertEquals('example.com', $container->getParameter('acme.section.frontend.host'));
         $this->assertEquals('^example\.com$', $container->getParameter('acme.section.frontend.host_pattern'));
         $this->assertEquals([], $container->getParameter('acme.section.frontend.defaults'));
@@ -319,6 +361,9 @@ final class SectionsConfiguratorTest extends TestCase
         $this->assertEquals('/', $container->getParameter('acme.section.frontend.prefix'));
         $this->assertEquals('^/(?!(backend)/)', $container->getParameter('acme.section.frontend.path'));
 
+        $this->assertFalse($container->getParameter('acme.section.backend.is_secure'));
+        $this->assertNull($container->getParameter('acme.section.backend.channel'));
+        $this->assertNull($container->getParameter('acme.section.backend.domain'));
         $this->assertEquals('example.{tld}', $container->getParameter('acme.section.backend.host'));
         $this->assertEquals('^example\.(?P<tld>com|net)$', $container->getParameter('acme.section.backend.host_pattern'));
         $this->assertEquals(['tld' => 'com'], $container->getParameter('acme.section.backend.defaults'));
@@ -344,15 +389,8 @@ final class SectionsConfiguratorTest extends TestCase
     public function it_throws_an_ValidatorException_when_section_conflicts()
     {
         $configurator = new SectionsConfigurator();
-        $configurator->set('first', new SectionConfiguration([
-            'prefix' => '/',
-            'host' => 'example.com',
-        ]));
-
-        $configurator->set('second', new SectionConfiguration([
-            'prefix' => '/', // same as 'first'
-            'host' => 'example.com',
-        ]));
+        $configurator->set('first', new SectionConfiguration('example.com/'));
+        $configurator->set('second', new SectionConfiguration('example.com/'));
 
         $failedSections = [
             // primary => [host, prefix, conflicts]
@@ -372,24 +410,9 @@ final class SectionsConfiguratorTest extends TestCase
     public function it_throws_an_ValidatorException_when_section_conflicts_with_patterns()
     {
         $configurator = new SectionsConfigurator();
-        $configurator->set('first', new SectionConfiguration([
-            'prefix' => '/',
-            'host' => 'example.{tld}',
-            'requirements' => ['tld' => 'com|net'],
-            'defaults' => ['tld' => 'com'],
-        ]));
-
-        $configurator->set('second', new SectionConfiguration([
-            'prefix' => '/', // same as 'first'
-            'host' => 'example.{ext}',
-            'requirements' => ['ext' => 'com|net'],
-            'defaults' => ['ext' => 'net'],
-        ]));
-
-        $configurator->set('third', new SectionConfiguration([
-            'prefix' => '/app',
-            'host' => 'example.com',
-        ]));
+        $configurator->set('first', new SectionConfiguration('example.{tld;com;com|net}/'));
+        $configurator->set('second', new SectionConfiguration('example.{ext;net;com|net}/'));
+        $configurator->set('third', new SectionConfiguration('example.com/app'));
 
         $failedSections = [
             // primary => [host, prefix, conflicts]
@@ -412,32 +435,14 @@ final class SectionsConfiguratorTest extends TestCase
     public function it_throws_an_ValidatorException_when_sections_conflicts()
     {
         $configurator = new SectionsConfigurator();
-        $configurator->set('first', new SectionConfiguration([
-            'prefix' => '/',
-            'host' => 'example.com',
-        ]));
+        $configurator->set('first', new SectionConfiguration('example.com/'));
+        $configurator->set('second', new SectionConfiguration('example.com/'));
+        $configurator->set('third', new SectionConfiguration('example.com/'));
 
-        $configurator->set('second', new SectionConfiguration([
-            'prefix' => '/', // same as 'first'
-            'host' => 'example.com',
-        ]));
+        $configurator->set('first1', new SectionConfiguration('/foo'));
+        $configurator->set('second2', new SectionConfiguration('/foo'));
 
-        $configurator->set('third', new SectionConfiguration([
-            'prefix' => '/', // same as 'first'
-            'host' => 'example.com',
-        ]));
-
-        $configurator->set('first1', new SectionConfiguration([
-            'prefix' => '/foo',
-        ]));
-
-        $configurator->set('second2', new SectionConfiguration([
-            'prefix' => '/foo', // same as 'first1'
-        ]));
-
-        $configurator->set('good', new SectionConfiguration([
-            'prefix' => '/something',
-        ]));
+        $configurator->set('good', new SectionConfiguration('/something'));
 
         $failedSections = [
             // primary => [host, prefix, conflicts]
@@ -461,34 +466,15 @@ final class SectionsConfiguratorTest extends TestCase
     public function it_throws_an_ValidatorException_when_sections_conflicts_by_prefix_and_no_host()
     {
         $configurator = new SectionsConfigurator();
-        $configurator->set('first', new SectionConfiguration([
-            'prefix' => '/',
-            'host' => 'example.com',
-        ]));
-
-        $configurator->set('second', new SectionConfiguration([
-            'prefix' => '/', // same as 'first'
-            'host' => 'example.com',
-        ]));
-
-        $configurator->set('third', new SectionConfiguration([
-            'prefix' => '/', // same as 'first'
-            'host' => 'example.com',
-        ]));
+        $configurator->set('first', new SectionConfiguration('example.com/'));
+        $configurator->set('second', new SectionConfiguration('example.com/'));
+        $configurator->set('third', new SectionConfiguration('example.com/'));
 
         //
         // conflicts with 'first', no host (so '*') and equal prefix '/'
-        $configurator->set('first1', new SectionConfiguration([
-            'prefix' => '/', // conflicts with 'first' because of no host and equal '/'
-        ]));
-
-        $configurator->set('second2', new SectionConfiguration([
-            'prefix' => '/', // conflicts with 'first' because of no host and equal '/'
-        ]));
-
-        $configurator->set('good', new SectionConfiguration([
-            'prefix' => '/something',
-        ]));
+        $configurator->set('first1', new SectionConfiguration('/')); // conflicts with 'first' because of no host and equal '/'
+        $configurator->set('second2', new SectionConfiguration('/')); // conflicts with 'first' because of no host and equal '/'
+        $configurator->set('good', new SectionConfiguration('/something'));
 
         $failedSections = [
             // primary => [host, prefix, conflicts]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #20 #19 
| License       | MIT

This removes support for configuring using array or JSON (introduced in #18) and only allows configuring using a developer friendly string format which looks 90% the same like an URL.

The internal code is almost completely redesigned for a much cleaner system.
All classes except the SectioningFactory and RouteLoader are now internal.

**Big bonus:** It's now possible to specify https is required with the host or using `https://*/prefix` 🤘